### PR TITLE
fix performance regression

### DIFF
--- a/R/create_se.R
+++ b/R/create_se.R
@@ -276,6 +276,7 @@ cbind_sparse <- function(mats) {
   rn <- unique(unlist(lapply(mats, rownames)))
   cn <- unique(unlist(lapply(mats, colnames)))
   nvals <- sum(unlist(lapply(mats, Matrix::nnzero)))
+
   if(nvals > 0){
     x <- integer(nvals)
     i <- integer(nvals)
@@ -288,9 +289,12 @@ cbind_sparse <- function(mats) {
       ind <- summary(mats[[idx]])
       nval <- nrow(ind)
       end <- nval + init_x - 1
-      i[init_x:end] <- rindnew[ind$i]
-      j[init_x:end] <- cindnew[ind$j]
-      x[init_x:end] <- ind$x
+      # handle binding a zero entry matrix to a non-zero
+      if(nval > 0){
+        i[init_x:end] <- rindnew[ind$i]
+        j[init_x:end] <- cindnew[ind$j]
+        x[init_x:end] <- ind$x
+      }
       init_x <- end + 1
     }
 
@@ -300,6 +304,7 @@ cbind_sparse <- function(mats) {
                         dims=c(length(rn), length(cn)),
                         dimnames=list(rn, cn))
   } else {
+    # handle binding a zero entry matrices
     res <- sparseMatrix(i = integer(0),
                         p = 0,
                         dims=c(length(rn), length(cn)),

--- a/R/pileup.R
+++ b/R/pileup.R
@@ -46,7 +46,7 @@
 #' fp <- FilterParam(only_keep_variants = TRUE, min_nucleotide_depth = 55)
 #' get_pileup(bamfn, fafn, filterParam = fp)
 #'
-#' @importFrom Rsamtools bgzip indexTabix TabixFile scanTabix
+#' @importFrom Rsamtools bgzip indexTabix TabixFile scanTabix scanFaIndex
 #' @importFrom GenomicRanges GRanges
 #' @importFrom IRanges IRanges
 #' @importFrom GenomeInfoDb seqlevels seqinfo seqlengths
@@ -132,6 +132,17 @@ get_pileup <- function(bamfiles,
     warning("the following chromosomes are not present in the bamfile(s):\n",
       paste(missing_chroms, collapse = "\n"),
       call. = FALSE
+    )
+    chroms_to_process <- setdiff(chroms_to_process, missing_chroms)
+  }
+
+  chroms_in_fa <- seqnames(Rsamtools::scanFaIndex(fafile))
+  missing_chroms <- chroms_to_process[!chroms_to_process %in% levels(chroms_in_fa)]
+
+  if(length(missing_chroms) > 0){
+    warning("the following chromosomes are not present in the fasta file:\n",
+            paste(missing_chroms, collapse = "\n"),
+            call. = FALSE
     )
     chroms_to_process <- setdiff(chroms_to_process, missing_chroms)
   }

--- a/tests/testthat/test_indexing.R
+++ b/tests/testthat/test_indexing.R
@@ -1,4 +1,3 @@
-context("indexing")
 library(GenomicRanges)
 library(GenomicAlignments)
 library(Rsamtools)

--- a/tests/testthat/test_pileup.R
+++ b/tests/testthat/test_pileup.R
@@ -1,5 +1,3 @@
-context("get_pileup")
-
 library(GenomicRanges)
 library(GenomicAlignments)
 library(Biostrings)
@@ -579,3 +577,8 @@ test_that("sites within short splice overhangs can be excluded", {
   expect_equal(length(res), 0)
 })
 unlink(c(tmp, sort_cbbam, idx))
+
+test_that("chroms missing from fasta file will not be processed", {
+  mfafn <- raer_example("mouse_tiny.fasta")
+  expect_error(expect_warning(get_pileup(bamfn, mfafn, bedfn)))
+})

--- a/tests/testthat/test_sc.R
+++ b/tests/testthat/test_sc.R
@@ -1,5 +1,3 @@
-context("sc_editing")
-
 library(BiocParallel)
 
 bamfn <- raer_example("5k_neuron_mouse_xf25_1pct_cbsort.bam")

--- a/tests/testthat/test_se.R
+++ b/tests/testthat/test_se.R
@@ -1,5 +1,3 @@
-context("create_se")
-
 library(GenomicRanges)
 library(SummarizedExperiment)
 


### PR DESCRIPTION
querying the reference sequence in `readaln` slowed down `get_pileup`, particualrly with many bamfiles and is unnecessary to guard against OOB reads (will return a N for the sequence). 

also added some additional checks for matrix binding code. 