### PR TITLE
implement progress bar for pileup

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,7 +41,8 @@ Imports:
     rtracklayer,
     stringr,
     fastmap,
-    Matrix
+    Matrix,
+    cli
 Suggests:
     testthat (>= 3.0.0),
     knitr,
@@ -60,7 +61,8 @@ Suggests:
     AnnotationHub
 LinkingTo: 
     Rcpp,
-    Rhtslib (>= 2.0.0)
+    Rhtslib (>= 2.0.0),
+    cli
 SystemRequirements: 
     C++11, 
     GNU make, 


### PR DESCRIPTION
closes #49

Rough implementation of a progress bar for run_cpileup.

Ideally the progress would be based on the number of sites to be evaluated instead of `NA_REAL` and `n_iter`, but I'm not sure where that information is stored.

Currently it counts up; if based on the number of sites I think this would convert to a percentage based countdown:

<img width="392" alt="image" src="https://user-images.githubusercontent.com/355367/212747159-f67bc74b-2b6c-4513-b236-1cac521a1c76.png">

Based on https://cli.r-lib.org/articles/progress-advanced.html#the-c-api