### PR TITLE
rsamtools devel version not needed

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ Imports:
     R.utils,
     GenomicRanges,
     IRanges,
-    Rsamtools (>= 2.15.1),
+    Rsamtools,
     BSgenome,
     Biostrings,
     SummarizedExperiment,


### PR DESCRIPTION
Removing the version specification as we don't call the new functionality e.g. `sortBam(byTag)` from v 2.15.1 in the code base. This should simplify installation.