### PR TITLE
exclude multiallelics and other improvements

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,15 @@
 # raer 0.99.0
 
+* Changed `filterParam` argument in `pileup_sites` and `pileup_cells` to `param` for
+simplicity
+
+* Added `FilterParam` to exclude multi-allelic sites `report_multiallelic`, or exclude reporting a variant in the Var assay based on allelic frequency (`min_allelic_freq`).
+
+* The `bam_flags` parameter used in `pileup_sites` and `pileup_cells` has been moved into the `FilterParam` class. 
+
+* The `bedindex` parameter for `pileup_sites` has been removed. This option is not needed
+at the user level and is planned to be replaced by the regional indexing used in `pileup_cells()`.
+
 * Added `FilterParam` option to trim reads based on fractional distance from 5' (`ftrim_5p`) or 3' end (`ftrim_3p`).
 
 * Incorporated RBPZ and VDB statistics from bcftools, now returned as rowData columns 

--- a/R/calc_AEI.R
+++ b/R/calc_AEI.R
@@ -27,7 +27,7 @@
 #'   a GRanges to snp_db rather than supplying all known SNPs (see
 #'   [get_overlapping_snps()]). Combined with using a bedfile for alu_ranges can
 #'   also will save time.
-#' @param filterParam object of class [FilterParam()] which specify various
+#' @param param object of class [FilterParam()] which specify various
 #'   filters to apply to reads and sites during pileup.
 #' @param BPPARAM A [BiocParallelParam] object for specifying parallel options
 #'   for operating over chromosomes.
@@ -59,7 +59,7 @@ calc_AEI <- function(bam_fn,
                      alu_ranges = NULL,
                      txdb = NULL,
                      snp_db = NULL,
-                     filterParam = FilterParam(),
+                     param = FilterParam(),
                      BPPARAM = SerialParam(),
                      verbose = FALSE) {
   chroms <- names(Rsamtools::scanBamHeader(bam_fn)[[1]]$targets)
@@ -80,11 +80,11 @@ calc_AEI <- function(bam_fn,
   genes_gr <- NULL
   tmp_files <- NULL
   alu_bed_fn <- NULL
-  if (filterParam@library_type %in% c("unstranded", "genomic-unstranded")) {
+  if (param@library_type %in% c("unstranded", "genomic-unstranded")) {
     if (is.null(txdb)) {
       stop("txdb required for processing unstranded data")
     }
-    filterParam@library_type == "genomic-unstranded"
+    param@library_type == "genomic-unstranded"
     if (is(txdb, "TxDb")) {
       genes_gr <- suppressWarnings(GenomicFeatures::genes(txdb))
     } else {
@@ -152,7 +152,7 @@ calc_AEI <- function(bam_fn,
         bam_fn = bam_fn,
         fasta_fn = fasta_fn,
         alu_bed_fn = alu_bed_fn,
-        filterParam = filterParam,
+        param = param,
         snp_gr = NULL,
         genes_gr = genes_gr,
         verbose = verbose
@@ -171,7 +171,7 @@ calc_AEI <- function(bam_fn,
         bam_fn = bam_fn,
         fasta_fn = fasta_fn,
         alu_bed_fn = alu_bed_fn,
-        filterParam = filterParam,
+        param = param,
         genes_gr = genes_gr,
         verbose = verbose
       ),
@@ -204,7 +204,7 @@ calc_AEI <- function(bam_fn,
                                 fasta_fn,
                                 alu_bed_fn,
                                 chrom,
-                                filterParam,
+                                param,
                                 snp_gr,
                                 genes_gr,
                                 verbose) {
@@ -212,14 +212,14 @@ calc_AEI <- function(bam_fn,
     start <- Sys.time()
     message("\tworking on: ", chrom, " time: ", Sys.time())
   }
-  filterParam@min_nucleotide_depth <- 1L
-  filterParam@only_keep_variants <- FALSE
+  param@min_depth <- 1L
+  param@only_keep_variants <- FALSE
 
   plp <- pileup_sites(bam_fn,
     fafile = fasta_fn,
     bedfile = alu_bed_fn,
     chroms = chrom,
-    filterParam = filterParam
+    param = param
   )
 
   if (!is.null(snp_gr) && !is.null(plp)) {
@@ -229,7 +229,7 @@ calc_AEI <- function(bam_fn,
     )
   }
 
-  if (filterParam@library_type == "genomic-unstranded") {
+  if (param@library_type == "genomic-unstranded") {
     plp <- correct_strand(plp, genes_gr)
   }
 
@@ -334,7 +334,7 @@ get_overlapping_snps <- function(gr,
 #' bamfn <- raer_example("SRR5564269_Aligned.sortedByCoord.out.md.bam")
 #' fafn <- raer_example("human.fasta")
 #' fp <- FilterParam(library_type = "genomic-unstranded")
-#' rse <- pileup_sites(bamfn, fafn, filterParam = fp)
+#' rse <- pileup_sites(bamfn, fafn, param = fp)
 #'
 #' genes <- GRanges(c(
 #'   "DHFR:200-400:+",

--- a/R/differential_editing.R
+++ b/R/differential_editing.R
@@ -267,7 +267,7 @@ prep_for_de <- function(se,
 #' names(bams) <- sample_ids
 #'
 #' fp <- FilterParam(only_keep_variants = TRUE)
-#' rse <- pileup_sites(bams, fafn, filterParam = fp)
+#' rse <- pileup_sites(bams, fafn, param = fp)
 #' rse$condition <- substr(rse$sample, 1, 2)
 #'
 #' rse <- calc_edit_frequency(rse)

--- a/R/pileup.R
+++ b/R/pileup.R
@@ -708,7 +708,7 @@ FilterParam <-
            indel_dist = 0L,splice_dist = 0L,  min_splice_overhang = 0L,
            homopolymer_len = 0L,
            max_mismatch_type = c(0L, 0L), read_bqual = c(0.0, 0.0),
-           min_variant_reads = 0L, min_allelic_freq = 0.01,
+           min_variant_reads = 0L, min_allelic_freq = 0,
            report_multiallelic = TRUE, ignore_query_Ns = FALSE) {
 
     stopifnot(isSingleNumber(max_depth))

--- a/R/sc-pileup.R
+++ b/R/sc-pileup.R
@@ -73,11 +73,10 @@ pileup_cells <- function(bamfile,
                       sites,
                       cell_barcodes,
                       output_directory,
-                      bam_flags = NULL,
                       chroms = NULL,
                       umi_tag = "UB",
                       cb_tag = "CB",
-                      fp = FilterParam(),
+                      param = FilterParam(),
                       BPPARAM = SerialParam(),
                       return_sce = TRUE,
                       verbose = FALSE) {
@@ -93,16 +92,14 @@ pileup_cells <- function(bamfile,
   }
 
   stopifnot(is(sites, "GRanges"))
-  if(is.null(bam_flags)){
-    bam_flags <- Rsamtools::scanBamFlag(
+
+  ## set default bam flags if not supplied
+  if(identical(param@bam_flags, Rsamtools::scanBamFlag())){
+    param@bam_flags <- Rsamtools::scanBamFlag(
       isSecondaryAlignment = FALSE,
       isSupplementaryAlignment = FALSE,
       isNotPassingQualityControls = FALSE
     )
-  } else {
-    if (length(bam_flags) != 2 || !all(names(bam_flags) == c("keep0", "keep1"))) {
-      stop("bam_flags must be generated using Rsamtools::scanBamFlag()")
-    }
   }
 
   cell_barcodes <- cell_barcodes[!is.na(cell_barcodes)]
@@ -128,10 +125,10 @@ pileup_cells <- function(bamfile,
     chroms_to_process <- intersect(chroms, chroms_to_process)
   }
 
-  fp <- .adjustParams(fp, 1)
+  fp <- .adjustParams(param, 1)
   fp <- .as.list_FilterParam(fp)
 
-  lib_code <- encode_library_type(fp$library_type)
+  lib_code <- fp$library_type
 
   event_filters <- unlist(fp[c(
     "trim_5p",
@@ -153,7 +150,6 @@ pileup_cells <- function(bamfile,
                               sites = sites,
                               barcodes = cell_barcodes,
                               outfile_prefix = output_directory,
-                              bam_flags = bam_flags,
                               cb_tag = cb_tag,
                               umi_tag = umi_tag,
                               libtype_code = lib_code,
@@ -256,8 +252,8 @@ read_sparray <- function(mtx_fn, sites_fn, bc_fn){
 # Utilities -------------------------------------------------------
 
 get_sc_pileup <- function(bamfn, sites, barcodes,
-                          outfile_prefix, bam_flags,
-                          chrom, umi_tag, cb_tag, libtype_code,
+                          outfile_prefix, chrom,
+                          umi_tag, cb_tag, libtype_code,
                           event_filters, fp, verbose){
   sites <- sites[seqnames(sites) %in% chrom, ]
   if(length(sites) == 0) return(character())
@@ -278,9 +274,9 @@ get_sc_pileup <- function(bamfn, sites, barcodes,
                fp$min_mapq,
                fp$max_depth,
                fp$min_base_quality,
-               fp$min_read_bqual,
+               fp$read_bqual,
                as.integer(libtype_code),
-               bam_flags,
+               fp$bam_flags,
                chr_outfns,
                umi_tag,
                FALSE,
@@ -337,23 +333,3 @@ check_tag <- function(x) {
   }
 }
 
-# encode libtype as
-# 0 = genomic-unstranded  all reads on + strand
-# 1 = fr-first-strand     strand based on R1/antisense, R2/sense
-# 2 = fr-second-strand    strand based on R1/sense, R2/antisense
-# 3 = unstranded          strand based on alignment
-encode_library_type <- function(x) {
-  lib_values <- c(
-    "genomic-unstranded",
-    "fr-first-strand",
-    "fr-second-strand",
-    "unstranded"
-  )
-  lib_code <- match(x, lib_values)
-  if (any(is.na(lib_code))) {
-    stop("library_type must be one of :", paste(lib_values, collapse = " "))
-  } else {
-    lib_code <- lib_code - 1
-  }
-  lib_code
-}

--- a/R/sc-pileup.R
+++ b/R/sc-pileup.R
@@ -23,9 +23,7 @@
 #' @param chroms A character vector of chromosomes to process, if supplied, only
 #'   sites present in the listed chromosomes will be processed
 #' @param cell_barcodes A character vector of single cell barcodes to process.
-#' @param bam_flags bam flags to filter or keep, use [Rsamtools::scanBamFlag()]
-#'   to generate
-#' @param fp object of class [FilterParam()] which specify various filters to
+#' @param param object of class [FilterParam()] which specify various filters to
 #'   apply to reads and sites during pileup. Note that the `min_variant_reads`
 #'   parameter, if set > 0, specifies the number of variant reads at a site
 #'   required in order to report a site. E.g. if set to 2, then at least 2 reads
@@ -60,7 +58,7 @@
 #' on.exit(unlink(outdir, bai))
 #'
 #' fp <- FilterParam(library_type = "fr-second-strand")
-#' sce <- pileup_cells(bam_fn, gr, cbs, outdir, fp = fp)
+#' sce <- pileup_cells(bam_fn, gr, cbs, outdir, param = fp)
 #' sce
 #'
 #' @importFrom GenomeInfoDb  seqinfo seqlengths

--- a/README.Rmd
+++ b/README.Rmd
@@ -74,10 +74,10 @@ The `FilterParam()` class holds multiple options for customizing the output of
 fp <- FilterParam(
   only_keep_variants = TRUE,
   library_type = "fr-first-strand",
-  min_nucleotide_depth = 2
+  min_depth = 2
 )
 
-rse <- pileup_sites(bams, fafn, filterParam = fp)
+rse <- pileup_sites(bams, fafn, param = fp)
 rse
 ```
 

--- a/README.md
+++ b/README.md
@@ -88,10 +88,10 @@ output of `pileup_sites()`.
 fp <- FilterParam(
   only_keep_variants = TRUE,
   library_type = "fr-first-strand",
-  min_nucleotide_depth = 2
+  min_depth = 2
 )
 
-rse <- pileup_sites(bams, fafn, filterParam = fp)
+rse <- pileup_sites(bams, fafn, param = fp)
 rse
 #> class: RangedSummarizedExperiment 
 #> dim: 74 2 

--- a/man/calc_AEI.Rd
+++ b/man/calc_AEI.Rd
@@ -10,7 +10,7 @@ calc_AEI(
   alu_ranges = NULL,
   txdb = NULL,
   snp_db = NULL,
-  filterParam = FilterParam(),
+  param = FilterParam(),
   BPPARAM = SerialParam(),
   verbose = FALSE
 )
@@ -36,7 +36,7 @@ a GRanges to snp_db rather than supplying all known SNPs (see
 \code{\link[=get_overlapping_snps]{get_overlapping_snps()}}). Combined with using a bedfile for alu_ranges can
 also will save time.}
 
-\item{filterParam}{object of class \code{\link[=FilterParam]{FilterParam()}} which specify various
+\item{param}{object of class \code{\link[=FilterParam]{FilterParam()}} which specify various
 filters to apply to reads and sites during pileup.}
 
 \item{BPPARAM}{A \link{BiocParallelParam} object for specifying parallel options

--- a/man/correct_strand.Rd
+++ b/man/correct_strand.Rd
@@ -32,7 +32,7 @@ suppressPackageStartupMessages(library("GenomicRanges"))
 bamfn <- raer_example("SRR5564269_Aligned.sortedByCoord.out.md.bam")
 fafn <- raer_example("human.fasta")
 fp <- FilterParam(library_type = "genomic-unstranded")
-rse <- pileup_sites(bamfn, fafn, filterParam = fp)
+rse <- pileup_sites(bamfn, fafn, param = fp)
 
 genes <- GRanges(c(
   "DHFR:200-400:+",

--- a/man/perform_de.Rd
+++ b/man/perform_de.Rd
@@ -59,7 +59,7 @@ sample_ids <- paste0(rep(c("KO", "WT"), each = 3), 1:3)
 names(bams) <- sample_ids
 
 fp <- FilterParam(only_keep_variants = TRUE)
-rse <- pileup_sites(bams, fafn, filterParam = fp)
+rse <- pileup_sites(bams, fafn, param = fp)
 rse$condition <- substr(rse$sample, 1, 2)
 
 rse <- calc_edit_frequency(rse)

--- a/man/pileup_cells.Rd
+++ b/man/pileup_cells.Rd
@@ -9,11 +9,10 @@ pileup_cells(
   sites,
   cell_barcodes,
   output_directory,
-  bam_flags = NULL,
   chroms = NULL,
   umi_tag = "UB",
   cb_tag = "CB",
-  fp = FilterParam(),
+  param = FilterParam(),
   BPPARAM = SerialParam(),
   return_sce = TRUE,
   verbose = FALSE
@@ -30,22 +29,12 @@ valid formatting.}
 \item{output_directory}{Output directory for output files. Will be generated
 if it doesn't exist.}
 
-\item{bam_flags}{bam flags to filter or keep, use \code{\link[Rsamtools:ScanBamParam-class]{Rsamtools::scanBamFlag()}}
-to generate}
-
 \item{chroms}{A character vector of chromosomes to process, if supplied, only
 sites present in the listed chromosomes will be processed}
 
 \item{umi_tag}{tag in bam containing the UMI sequence}
 
 \item{cb_tag}{tag in bam containing the cell barcode sequence}
-
-\item{fp}{object of class \code{\link[=FilterParam]{FilterParam()}} which specify various filters to
-apply to reads and sites during pileup. Note that the \code{min_variant_reads}
-parameter, if set > 0, specifies the number of variant reads at a site
-required in order to report a site. E.g. if set to 2, then at least 2 reads
-(from any cell) must have a variant in order to report the site. The
-default of 0 reports all sites present in the \code{sites} object.}
 
 \item{BPPARAM}{BiocParallel instance. Parallel computation occurs across
 chromosomes.}
@@ -55,6 +44,16 @@ chromosomes.}
 \code{outfile_prefix}, will be returned.}
 
 \item{verbose}{Display messages}
+
+\item{bam_flags}{bam flags to filter or keep, use \code{\link[Rsamtools:ScanBamParam-class]{Rsamtools::scanBamFlag()}}
+to generate}
+
+\item{fp}{object of class \code{\link[=FilterParam]{FilterParam()}} which specify various filters to
+apply to reads and sites during pileup. Note that the \code{min_variant_reads}
+parameter, if set > 0, specifies the number of variant reads at a site
+required in order to report a site. E.g. if set to 2, then at least 2 reads
+(from any cell) must have a variant in order to report the site. The
+default of 0 reports all sites present in the \code{sites} object.}
 }
 \value{
 Returns either a \code{SingleCellExperiment} or character vector of paths

--- a/man/pileup_cells.Rd
+++ b/man/pileup_cells.Rd
@@ -36,6 +36,13 @@ sites present in the listed chromosomes will be processed}
 
 \item{cb_tag}{tag in bam containing the cell barcode sequence}
 
+\item{param}{object of class \code{\link[=FilterParam]{FilterParam()}} which specify various filters to
+apply to reads and sites during pileup. Note that the \code{min_variant_reads}
+parameter, if set > 0, specifies the number of variant reads at a site
+required in order to report a site. E.g. if set to 2, then at least 2 reads
+(from any cell) must have a variant in order to report the site. The
+default of 0 reports all sites present in the \code{sites} object.}
+
 \item{BPPARAM}{BiocParallel instance. Parallel computation occurs across
 chromosomes.}
 
@@ -44,16 +51,6 @@ chromosomes.}
 \code{outfile_prefix}, will be returned.}
 
 \item{verbose}{Display messages}
-
-\item{bam_flags}{bam flags to filter or keep, use \code{\link[Rsamtools:ScanBamParam-class]{Rsamtools::scanBamFlag()}}
-to generate}
-
-\item{fp}{object of class \code{\link[=FilterParam]{FilterParam()}} which specify various filters to
-apply to reads and sites during pileup. Note that the \code{min_variant_reads}
-parameter, if set > 0, specifies the number of variant reads at a site
-required in order to report a site. E.g. if set to 2, then at least 2 reads
-(from any cell) must have a variant in order to report the site. The
-default of 0 reports all sites present in the \code{sites} object.}
 }
 \value{
 Returns either a \code{SingleCellExperiment} or character vector of paths
@@ -92,7 +89,7 @@ bai <- indexBam(bam_fn)
 on.exit(unlink(outdir, bai))
 
 fp <- FilterParam(library_type = "fr-second-strand")
-sce <- pileup_cells(bam_fn, gr, cbs, outdir, fp = fp)
+sce <- pileup_cells(bam_fn, gr, cbs, outdir, param = fp)
 sce
 
 }

--- a/man/pileup_sites.Rd
+++ b/man/pileup_sites.Rd
@@ -11,10 +11,8 @@ pileup_sites(
   bedfile = NULL,
   region = NULL,
   chroms = NULL,
-  filterParam = FilterParam(),
+  param = FilterParam(),
   outfile_prefix = NULL,
-  bedidx = NULL,
-  bam_flags = NULL,
   reads = NULL,
   return_data = TRUE,
   BPPARAM = SerialParam(),
@@ -26,10 +24,11 @@ pileup_sites(
 
 FilterParam(
   max_depth = 10000,
+  min_depth = 1L,
   min_base_quality = 20L,
   min_mapq = 0L,
-  min_nucleotide_depth = 1L,
   library_type = "fr-first-strand",
+  bam_flags = NULL,
   only_keep_variants = FALSE,
   trim_5p = 0L,
   trim_3p = 0L,
@@ -37,11 +36,13 @@ FilterParam(
   ftrim_3p = 0,
   indel_dist = 0L,
   splice_dist = 0L,
+  min_splice_overhang = 0L,
   homopolymer_len = 0L,
   max_mismatch_type = c(0L, 0L),
-  min_read_bqual = c(0, 0),
-  min_splice_overhang = 0L,
+  read_bqual = c(0, 0),
   min_variant_reads = 0L,
+  min_allelic_freq = 0.01,
+  report_multiallelic = TRUE,
   ignore_query_Ns = FALSE
 )
 }
@@ -58,17 +59,11 @@ the colData will be populated with the basename of the bamfile.}
 
 \item{chroms}{chromosomes to process, not to be used with region}
 
-\item{filterParam}{object of class \code{\link[=FilterParam]{FilterParam()}} which specify various
+\item{param}{object of class \code{\link[=FilterParam]{FilterParam()}} which specify various
 filters to apply to reads and sites during pileup.}
 
 \item{outfile_prefix}{Output prefix for tabix indexed files. If \code{NULL}, no
 files will be produced.}
-
-\item{bedidx}{A BedFile object, if supplied, pileup will use index generated
-by \code{\link[=indexBed]{indexBed()}}}
-
-\item{bam_flags}{bam flags to filter or keep, use \code{\link[Rsamtools:ScanBamParam-class]{Rsamtools::scanBamFlag()}}
-to generate}
 
 \item{reads}{if supplied a fasta file will be written with reads that pass
 filters and contain variants}
@@ -99,17 +94,20 @@ reads with the same UMI sequence will only be counted once per position.}
 
 \item{max_depth}{maximum read depth considered at each site}
 
+\item{min_depth}{min read depth needed to report site}
+
 \item{min_base_quality}{min base quality score to consider read for pileup}
 
 \item{min_mapq}{minimum required MAPQ score, can be a vector of values
 for each bam file}
 
-\item{min_nucleotide_depth}{min read depth needed to report site}
-
 \item{library_type}{read orientation, one of fr-first-strand,
 fr-second-strand, unstranded, and genomic-unstranded. Can supply as a vector to specify for each
 input bam. Unstranded library type will be reported based on read alignment.
 genomic-unstranded will report all variants w.r.t the + strand.}
+
+\item{bam_flags}{bam flags to filter or keep, use \code{\link[Rsamtools:ScanBamParam-class]{Rsamtools::scanBamFlag()}}
+to generate.}
 
 \item{only_keep_variants}{if TRUE, then only variant sites will be reported
 (FALSE by default), can be a vector for each input bamfile}
@@ -128,6 +126,9 @@ distance from indel event in the read}
 \item{splice_dist}{Exclude read if site occurs within given
 distance from splicing event in the read}
 
+\item{min_splice_overhang}{Exclude read if site is located adjacent to splice
+site with an overhang of less than given length.}
+
 \item{homopolymer_len}{Exclude site if occurs within homopolymer of given
 length}
 
@@ -136,15 +137,18 @@ length}
 must be supplied as a integer vector of length 2. e.g.
 c(X, Y).}
 
-\item{min_read_bqual}{Exclude read if more than X percent of the bases have
+\item{read_bqual}{Exclude read if more than X percent of the bases have
 base qualities less than Y. Numeric vector of length 2. e.g. c(0.25, 20)}
-
-\item{min_splice_overhang}{Exclude read if site is located adjacent to splice
-site with an overhang of less than given length.}
 
 \item{min_variant_reads}{Required number of reads containing a variant for a site
 to be reported. Calculated per bam file, such that if 1 bam file has >= min_variant_reads,
 then the site will be reported.}
+
+\item{min_allelic_freq}{minimum allelic frequency required for a variant to be
+reported in Var assays.}
+
+\item{report_multiallelic}{if TRUE, report sites with multiple variants passing
+filters. If FALSE, site will not be reported.}
 
 \item{ignore_query_Ns}{ignored for now}
 }
@@ -169,8 +173,8 @@ fafn <- raer_example("human.fasta")
 
 rse <- pileup_sites(bamfn, fafn)
 
-fp <- FilterParam(only_keep_variants = TRUE, min_nucleotide_depth = 55)
-pileup_sites(bamfn, fafn, filterParam = fp)
+fp <- FilterParam(only_keep_variants = TRUE, min_depth = 55)
+pileup_sites(bamfn, fafn, param = fp)
 
 
 # using multiple bam files
@@ -184,7 +188,7 @@ sample_ids <- paste0(rep(c("KO", "WT"), each = 3), 1:3)
 names(bams) <- sample_ids
 
 fp <- FilterParam(only_keep_variants = TRUE)
-rse <- pileup_sites(bams, fafn, filterParam = fp)
+rse <- pileup_sites(bams, fafn, param = fp)
 rse
 
 rse$condition <- substr(rse$sample, 1, 2)

--- a/man/pileup_sites.Rd
+++ b/man/pileup_sites.Rd
@@ -41,7 +41,7 @@ FilterParam(
   max_mismatch_type = c(0L, 0L),
   read_bqual = c(0, 0),
   min_variant_reads = 0L,
-  min_allelic_freq = 0.01,
+  min_allelic_freq = 0,
   report_multiallelic = TRUE,
   ignore_query_Ns = FALSE
 )

--- a/man/sc_editing.Rd
+++ b/man/sc_editing.Rd
@@ -13,8 +13,8 @@ sc_editing(
   tag_index_args = list(tag = "CB"),
   BPPARAM = SerialParam(),
   batch_size = 50,
-  bam_flags = NULL,
   umi_tag = "UB",
+  param = FilterParam(),
   verbose = TRUE,
   ...
 )
@@ -47,9 +47,10 @@ Batching the cells reduces run time by avoiding  loading sequences from the
 fasta file for each cell. Setting values above 50 is unlikely to further improve
 runtime.}
 
-\item{bam_flags}{See arguments for \verb{[pileup_sites()]}}
-
 \item{umi_tag}{See arguments for \verb{[pileup_sites()]}}
+
+\item{param}{object of class \code{\link[=FilterParam]{FilterParam()}} which specify various
+filters to apply to reads and sites during pileup.}
 
 \item{verbose}{Display messages}
 
@@ -79,7 +80,7 @@ se <- sc_editing(
   bedfile = raer_example("5k_neuron_sites.bed.gz"),
   cell_barcodes = cbs[1:15],
   verbose = FALSE,
-  filterParam = fp
+  param = fp
 )
 
 # pool cell barcodes across clusters
@@ -97,7 +98,7 @@ se <- sc_editing(
   cell_barcodes = cb_lst,
   umi_tag = NULL,
   verbose = FALSE,
-  filterParam = fp
+  param = fp
 )
 assays(se)$nA
 assays(se)$nG

--- a/src/init.c
+++ b/src/init.c
@@ -19,7 +19,7 @@ extern SEXP _raer_list_tabix_chroms(SEXP);
 extern SEXP _raer_c_show_index(SEXP, SEXP);
 extern SEXP bedfile_open(SEXP);
 extern SEXP bedfile_close(SEXP);
-extern SEXP pileup(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP pileup(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP scpileup(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 
 
@@ -34,7 +34,7 @@ static const R_CallMethodDef CallEntries[] = {
   {".bedfile_open", (DL_FUNC) &bedfile_open, 1},
   {".bedfile_close", (DL_FUNC) &bedfile_close, 1},
   {".isnull", (DL_FUNC) &isnull, 1},
-  {".pileup",(DL_FUNC) &pileup, 22},
+  {".pileup",(DL_FUNC) &pileup, 17},
   {".scpileup",(DL_FUNC) &scpileup, 17},
   {NULL, NULL, 0}
 };

--- a/tests/testthat/test_indexing.R
+++ b/tests/testthat/test_indexing.R
@@ -7,7 +7,6 @@ fafn <- system.file("extdata", "human.fasta", package = "raer")
 bedfn <- system.file("extdata", "regions.bed", package = "raer")
 idx <- indexBed(bedfn)
 
-#cbbam_fn <- system.file("extdata", "5k_neuron_mouse_xf25_1pct_cbsort.bam", package = "raer")
 cbbam_fn <- system.file("extdata", "5k_neuron_mouse_cbsort.bam", package = "raer")
 ubbam_fn <- system.file("extdata", "5k_neuron_mouse_xf25_1pct_ubsort.bam", package = "raer")
 
@@ -16,11 +15,6 @@ test_that("bedindex works", {
   expect_false(is_null_extptr(idx$.extptr))
 })
 
-test_that("bedindex can be used with pileup", {
-  res <- pileup_sites(bamfn, fafn, bedidx = idx)
-  res2 <- pileup_sites(bamfn, fafn, bedfile = bedfn)
-  expect_true(identical(res, res2))
-})
 
 test_that("close cleans up index", {
   idx <- close(idx)

--- a/tests/testthat/test_pileup.R
+++ b/tests/testthat/test_pileup.R
@@ -10,16 +10,8 @@ bamfn <- raer_example("SRR5564269_Aligned.sortedByCoord.out.md.bam")
 bam2fn <- raer_example("SRR5564277_Aligned.sortedByCoord.out.md.bam")
 fafn <- raer_example("human.fasta")
 bedfn <- raer_example("regions.bed")
-res <- pileup_sites(bamfn, fafn,
-                    param = FilterParam(
-                      read_bqual = c(0.25, 20),
-                      min_base_quality = 0L,
-                      library_type = c("genomic-unstranded")
-                    )
-)
 
 res <- pileup_sites(bamfn, fafn, bedfn)
-
 
 test_that("pileup works", {
   expect_equal(length(rowData(res)$Ref), 182)

--- a/tests/testthat/test_sc.R
+++ b/tests/testthat/test_sc.R
@@ -18,7 +18,7 @@ test_that("basic functionality works", {
     bedfile = raer_example("5k_neuron_sites.bed.gz"),
     cell_barcodes = cbs[1:15],
     verbose = FALSE,
-    filterParam = fp
+    param = fp
   )
   expect_equal(ncol(se), 15)
   expect_true(all(startsWith(colnames(se), "AAA")))
@@ -31,7 +31,7 @@ test_that("basic functionality works", {
     cell_barcodes = cb_lst,
     verbose = FALSE,
     umi_tag = NULL,
-    filterParam = fp
+    param = fp
   )
   expect_equal(ncol(se), 5)
   expect_true(all(startsWith(colnames(se), "cluster")))
@@ -58,7 +58,7 @@ test_that("umi deduplication works", {
     cell_barcodes = cbs[1:25],
     umi_tag = "UB",
     verbose = FALSE,
-    filterParam = fp
+    param = fp
   )
   se_noumi <- sc_editing(
     bamfile = bamfn,
@@ -67,7 +67,7 @@ test_that("umi deduplication works", {
     cell_barcodes = cbs[1:25],
     umi_tag = NULL,
     verbose = FALSE,
-    filterParam = fp
+    param = fp
   )
 
   av <- as.matrix(assays(se_umi)$nA)

--- a/tests/testthat/test_sp_sc.R
+++ b/tests/testthat/test_sp_sc.R
@@ -21,7 +21,7 @@ on.exit(unlink(outdir))
 
 test_that("basic functionality works", {
   fp <- FilterParam(library_type = "fr-second-strand")
-  sce <- pileup_cells(bam_fn, gr, cbs, outdir, fp = fp)
+  sce <- pileup_cells(bam_fn, gr, cbs, outdir, param = fp)
   expect_true(is(sce, "SingleCellExperiment"))
   expect_equal(dim(sce), c(5, 556))
   expect_true( all(colnames(sce) == cbs))
@@ -36,23 +36,23 @@ test_that("basic functionality works", {
 
   expect_warning(pileup_cells(bam_fn, gr,
                               c("non", "existent", "barcodes"),
-                              outdir, fp = fp))
+                              outdir, param = fp))
 
   expect_error(pileup_cells(bam_fn, as.data.frame(gr),
                             cbs, outdir, fp = fp))
   expect_error(pileup_cells(bam_fn, gr,
-                            1:10, outdir, fp = fp))
+                            1:10, outdir, param = fp))
 })
 
 test_that("ranges are correct", {
   fp <- FilterParam(library_type = "fr-second-strand")
-  sce <- pileup_cells(bam_fn, gr, cbs, outdir, fp = fp)
+  sce <- pileup_cells(bam_fn, gr, cbs, outdir, param = fp)
   expect_true(all(gr == rowRanges(sce)))
 
   # should drop 1 site with 0 reads
   fp <- FilterParam(library_type = "fr-second-strand",
                     min_variant_reads = 1)
-  sce <- pileup_cells(bam_fn, gr, cbs, outdir, fp = fp)
+  sce <- pileup_cells(bam_fn, gr, cbs, outdir, param = fp)
   expect_equal(nrow(sce), 4)
 })
 

--- a/vignettes/novel-sites.Rmd
+++ b/vignettes/novel-sites.Rmd
@@ -72,7 +72,7 @@ Filtering parameters for the `pileup_sites()` function can accept multiple argum
 
 ```{r}
 fp <- FilterParam(
-  min_nucleotide_depth = 1,
+  min_depth = 1,
   min_base_quality = 30,
   min_mapq = c(255, 30),
   library_type = c("fr-first-strand", "genomic-unstranded"),
@@ -81,7 +81,7 @@ fp <- FilterParam(
   indel_dist = 4,
   homopolymer_len = 6,
   max_mismatch_type = c(3, 3),
-  min_read_bqual = c(0.25, 20),
+  read_bqual = c(0.25, 20),
   only_keep_variants = c(TRUE, FALSE)
 )
 
@@ -90,7 +90,7 @@ names(bams) <- c("rna", "dna")
 rse <- pileup_sites(bams,
   fafile = fafn,
   chrom = "chr4",
-  filterParam = fp
+  param = fp
 )
 
 rse

--- a/vignettes/raer.Rmd
+++ b/vignettes/raer.Rmd
@@ -86,7 +86,7 @@ rse <- pileup_sites(bam_files,
   fafile = fafn,
   bedfile = bedfn,
   region = "chr18",
-  filterParam = fp
+  param = fp
 )
 ```
 

--- a/vignettes/single-cell.Rmd
+++ b/vignettes/single-cell.Rmd
@@ -95,7 +95,7 @@ e_sce <- pileup_cells(
   output_directory = outdir,
   cb_tag = "CB",
   umi_tag = "UB",
-  fp = FilterParam(
+  param = FilterParam(
     min_base_quality = 30L,
     library_type = "fr-second-strand",
     min_variant_reads = 1L,


### PR DESCRIPTION
related to #72 

 - Added `FilterParam` option to exclude multi-allelic sites `report_multiallelic`, or to exclude reporting a variant in the Var assay based on allelic frequency (`min_allelic_freq`). The two parameters, if used in combination, will exclude multiallelic sites with high primary and secondary variant allele frequencies.
- changed `filterParam` argument in `pileup_sites` and `pileup_cells` to `param` for simplicity. 
- renamed FilterParam parameter `min_nucleotide_depth` to `min_depth`
- renamed FilterParam parameter `min_read_bqual` to `read_bqual`
- moved `bam_flags` parameters to `FilterParams` class
- the `bedindex` parameter for `pileup_sites` has been removed. This option is not needed
at the user level and is planned to be replaced by the regional indexing used in `pileup_cells()`.
- update tests with new args
