### PR TITLE
Replace S4Vectors::aggregate() calls to fix vignette build on Bioc devel

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: raer
 Type: Package
 Title: RNA editing tools in R
-Version: 1.11.0
+Version: 1.11.1
 Authors@R: c(
     person("Kent", "Riemondy", , "kent.riemondy@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0750-1273")),

--- a/R/annot_rse.R
+++ b/R/annot_rse.R
@@ -107,12 +107,13 @@ annot_snps.GRanges <- function(
   }
 
   if (is.null(genome)) {
-    mcols(sites)[col_to_aggr] <- aggregate(
-      snps,
+    mcols(sites)[col_to_aggr] <- collapse_hits_annotations(
+      mcols(snps)[[col_to_aggr]],
       snp_overlaps,
-      snp = unstrsplit(eval(parse(text = col_to_aggr)), ","),
-      drop = FALSE
-    )$snp
+      length(sites),
+      sep = ",",
+      unique_values = FALSE
+    )
 
     if (RLE) {
       col_rle <- S4Vectors::Rle(mcols(sites)[[col_to_aggr]])
@@ -129,25 +130,27 @@ annot_snps.GRanges <- function(
       )
     }
 
-    # prevent no visible binding for global variable note
-    alt_alleles <- ref_allele <- NULL
-
     snps$alt_alleles <- vapply(
       snps$alt_alleles,
       function(x) paste0(unique(x), collapse = ","),
       FUN.VALUE = character(1)
     )
 
-    snp_info <- aggregate(
-      snps,
-      snp_overlaps,
-      snp = unstrsplit(eval(parse(text = col_to_aggr)), ","),
-      ref_allele = unstrsplit(ref_allele),
-      alt_alleles = unstrsplit(alt_alleles),
-      drop = FALSE
+    snp_info <- DataFrame(
+      collapse_hits_annotations(
+        mcols(snps)[[col_to_aggr]], snp_overlaps, length(sites),
+        sep = ",", unique_values = FALSE
+      ),
+      collapse_hits_annotations(
+        snps$ref_allele, snp_overlaps, length(sites),
+        sep = "", unique_values = FALSE
+      ),
+      collapse_hits_annotations(
+        snps$alt_alleles, snp_overlaps, length(sites),
+        sep = "", unique_values = FALSE
+      )
     )
 
-    snp_info$grouping <- NULL
     snp_cols <- c(
       col_to_aggr,
       "snp_ref_allele",
@@ -254,18 +257,13 @@ annot_from_gr <- function(obj, gr, cols_to_map, RLE = TRUE, sep = ",", ...) {
     if (!col %in% names(mcols(gr))) {
       cli::cli_abort("{col} not present in mcols() of input")
     }
-    mcols(gr)[[col]] <- as.character(mcols(gr)[[col]])
-    x <- aggregate(
-      gr,
+    tmp <- collapse_hits_annotations(
+      mcols(gr)[[col]],
       overlaps,
-      tmp = unstrsplit(
-        unique(eval(parse(text = col))),
-        sep = sep
-      ),
-      drop = FALSE
+      length(gr_sites),
+      sep = sep
     )
-    x$tmp <- ifelse(x$tmp == "", NA, x$tmp)
-    mcols(gr_sites)[[col_id]] <- x$tmp
+    mcols(gr_sites)[[col_id]] <- ifelse(tmp == "", NA, tmp)
   }
 
   if (RLE) {
@@ -283,4 +281,27 @@ annot_from_gr <- function(obj, gr, cols_to_map, RLE = TRUE, sep = ",", ...) {
   }
 
   obj
+}
+
+# Collapse subject-side annotation values onto each query interval, replicating
+# aggregate(x, hits, name = unstrsplit(<unique> col, sep), drop = FALSE)$name.
+# Implemented without S4Vectors::aggregate() because that function evaluates its
+# expressions in an environment built from the object's mcols columns, and in
+# recent S4Vectors versions this fails for any column lacking a same-named
+# accessor function (e.g. "swScore"), aborting with "object '<col>' of mode
+# 'function' was not found".
+collapse_hits_annotations <- function(values, hits, n_queries, sep = ",",
+                                      unique_values = TRUE) {
+  values <- as.character(values)
+  groups <- factor(queryHits(hits), levels = seq_len(n_queries))
+  parts <- split(values[subjectHits(hits)], groups)
+  # An empty group collapses to "" (as unstrsplit() does), which downstream
+  # code (e.g. check_snp_match()) uses to flag sites without an overlap.
+  out <- vapply(parts, function(v) {
+    if (unique_values) {
+      v <- unique(v)
+    }
+    paste0(v, collapse = sep)
+  }, character(1))
+  unname(out)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -141,14 +141,11 @@ find_mispriming_sites <- function(
   }
   close(bf)
   # merge again, handle edge cases between yieldsizes
-  mean_pal <- n_reads <- NULL
   ans <- reduce(pa_pks, with.revmap = TRUE)
-  mcols(ans) <- aggregate(
-    pa_pks,
-    mcols(ans)$revmap,
-    mean_pal = mean(mean_pal),
-    n_reads = sum(n_reads),
-    drop = FALSE
+  revmap <- mcols(ans)$revmap
+  mcols(ans) <- DataFrame(
+    mean_pal = mean(extractList(pa_pks$mean_pal, revmap)),
+    n_reads = sum(extractList(pa_pks$n_reads, revmap))
   )
 
   # keep reads above threshold, slop, and merge adjacent misprimed regions
@@ -162,15 +159,12 @@ find_mispriming_sites <- function(
   ans <- trim(ans)
 
   res <- reduce(ans, with.revmap = TRUE)
-  mcols(res) <- aggregate(
-    ans,
-    mcols(res)$revmap,
-    mean_pal = mean(mean_pal),
-    n_reads = sum(n_reads),
-    drop = FALSE
+  revmap <- mcols(res)$revmap
+  mcols(res) <- DataFrame(
+    mean_pal = mean(extractList(ans$mean_pal, revmap)),
+    n_reads = sum(extractList(ans$n_reads, revmap))
   )
-  res$n_regions <- IRanges::grouplengths(res$grouping)
-  res$grouping <- NULL
+  res$n_regions <- lengths(revmap)
   res <- pa_seq_context(res, fasta)
   res
 }
@@ -194,15 +188,12 @@ merge_pa_peaks <- function(gr) {
   end(gr[strand(gr) == "-"]) <- start(gr[strand(gr) == "-"])
 
   # merge and count reads within merged ivls
-  pa <- NULL
   ans <- reduce(gr, with.revmap = TRUE)
-  mcols(ans) <- aggregate(
-    gr,
-    mcols(ans)$revmap,
-    mean_pal = mean(pa),
-    drop = FALSE
+  revmap <- mcols(ans)$revmap
+  mcols(ans) <- DataFrame(
+    mean_pal = mean(extractList(gr$pa, revmap))
   )
-  mcols(ans)$n_reads <- grouplengths(ans$grouping)
+  mcols(ans)$n_reads <- lengths(revmap)
   ans
 }
 


### PR DESCRIPTION
Recent S4Vectors versions build the aggregate() evaluation environment from an object's mcols columns via makeFixedColumnEnv(), which requires a same-named accessor function for every column. Columns without one (e.g. rmsk's "swScore") abort with "object 'swScore' of mode 'function' was not found", breaking the vignette and any annot_from_gr()/annot_snps() call.

Replace all aggregate(x, by, expr, drop=FALSE) calls with explicit grouped reductions that do not rely on S4Vectors' non-standard evaluation:
- add internal collapse_hits_annotations() helper for the annotation-string collapses in annot_from_gr() and annot_snps()
- use extractList() + mean()/sum() for the numeric mispriming reductions in utils.R

Behavior is preserved, including empty groups collapsing to "" and annot_from_gr() converting those to NA. Bump version to 1.11.1.